### PR TITLE
Next-generation data models and document models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
-node_modules
-dist
-docs
-.idea*
+/.idea*/
+/.nova/
+/.vscode/
+
+/node_modules/
+/dist/
+/docs/
+
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reyah/api-sdk",
-  "version": "1.0.25",
+  "version": "1.1.0",
   "description": "Reyah API software development kit for developers written in TypeScript",
   "main": "dist/reyah.sdk.js",
   "types": "dist",

--- a/src/constructor/dataModel.ts
+++ b/src/constructor/dataModel.ts
@@ -7,34 +7,23 @@ import {
     FieldLink,
     PaginatedDataModels,
     PaginatedFields,
-    Property,
-} from '..';
+} from '../types/dataModel';
 import newPaginationStatus from './pagination';
-
-/**
- * Data model field property
- */
-export function newProperty(obj: any): Property {
-    return {
-        key: obj.key,
-        value: obj.value,
-    };
-}
 
 /**
  * Data model field
  */
 export function newField(obj: any): Field {
     return {
-        created_at: new Date(obj.created_at),
-        datatypes: obj.datatypes || [],
-        description: obj.description,
         field_id: obj.field_id,
+        user_id: obj.user_id,
         kind: obj.kind,
         name: obj.name,
-        properties: obj.properties?.map((elem: any) => newProperty(elem)) || [],
+        description: obj.description,
+        datatypes: obj.datatypes ?? [],
+        columns: obj.columns ?? [],
+        created_at: new Date(obj.created_at),
         updated_at: new Date(obj.updated_at),
-        user_id: obj.user_id,
     };
 }
 
@@ -58,7 +47,7 @@ export function newDataModel(obj: any): DataModel {
     return {
         created_at: new Date(obj.created_at),
         description: obj.description,
-        fields: obj.fields?.map((elem: any) => newField(elem)) || [],
+        fields: obj.fields?.map(newField) || [],
         model_id: obj.model_id,
         name: obj.name,
         updated_at: new Date(obj.updated_at),

--- a/src/constructor/documentModel.ts
+++ b/src/constructor/documentModel.ts
@@ -1,15 +1,91 @@
 import {
+    Anchor,
+    BoundingBox,
+    Column,
+    DocumentModelTableField,
+    Extent,
+    GatherBox,
+    Padding,
     DocumentModelField,
     DocumentModel,
     PaginatedDocumentModels,
     PreviewURL,
     PreviewURLs,
+    DocumentModelElementField,
+    Interval,
 } from '..';
 import newPaginationStatus from './pagination';
+
+
+export function newExtent(obj: any): Extent {
+    return {
+        fst: (typeof obj.fst === 'number') ? parseFloat(obj.fst) : undefined,
+        snd: (typeof obj.snd === 'number') ? parseFloat(obj.snd) : undefined,
+        trd: (typeof obj.trd === 'number') ? parseFloat(obj.trd) : undefined,
+    };
+}
+
+export function newPadding(obj: any): Padding {
+    return {
+        top: parseFloat(obj.top),
+        right: parseFloat(obj.right),
+        bottom: parseFloat(obj.bottom),
+        left: parseFloat(obj.left),
+    };
+}
+
+export function newInterval(obj: any): Interval {
+    return {
+        lo: parseFloat(obj.lo),
+        hi: parseFloat(obj.hi),
+    };
+}
+
+export function newBoundingBox(obj: any): BoundingBox {
+    return {
+        x: newInterval(obj.x),
+        y: newInterval(obj.y),
+    };
+}
+
+
+export function newColumn(obj: any): Column {
+    return {
+        label: obj.label,
+        width: parseFloat(obj.width),
+    };
+}
+
+export function newAnchor(obj: any): Anchor {
+    return {
+        orientation: obj.orientation,
+        box: newBoundingBox(obj.box),
+        label: obj.label,
+        padding: obj.padding && newPadding(obj.padding),
+    };
+}
+
+export function newGatherBox(obj: any): GatherBox {
+    return {
+        direction: obj.direction,
+        extent: newExtent(obj.extent),
+    };
+}
 
 /**
  * Document model service type definitions.
  */
+
+export function newDocumentModelElementField(/* obj: any */): DocumentModelElementField {
+    return {
+    };
+}
+
+export function newDocumentModelTableField(obj: any): DocumentModelTableField {
+    return {
+        columns: obj.columns?.map(newColumn) ?? [],
+    };
+}
 
 /**
  * Represents a single field of a document model.
@@ -20,12 +96,10 @@ export function newDocumentModelField(obj: any): DocumentModelField {
         name: obj.name,
         datamodel_field_id: obj.datamodel_field_id,
         description: obj.description,
-        height: parseFloat(obj.height),
-        width: parseFloat(obj.width),
-        x: parseFloat(obj.x),
-        y: parseFloat(obj.y),
-        created_at: new Date(obj.created_at),
-        updated_at: new Date(obj.updated_at),
+        anchor: newAnchor(obj.anchor),
+        gatherBox: newGatherBox(obj.gatherBox),
+        element: obj.element && newDocumentModelElementField(/* obj.element */),
+        table: obj.table && newDocumentModelTableField(obj.table),
     };
 }
 
@@ -42,12 +116,14 @@ export function newDocumentModelFields(obj: any[]): DocumentModelField[] {
 export function newDocumentModel(obj: any): DocumentModel {
     return {
         id: obj.id,
+        version: obj.version,
         user_id: obj.user_id,
-        preview_status: obj.preview_status,
+        name: obj.name,
         datamodel_id: obj.datamodel_id,
         description: obj.description,
         fields: newDocumentModelFields(obj.fields),
-        name: obj.name,
+        stoppers: obj.stoppers?.map(newAnchor) ?? [],
+        preview_status: obj.preview_status,
         created_at: new Date(obj.created_at),
         updated_at: new Date(obj.updated_at),
     };

--- a/src/constructor/documentModel.ts
+++ b/src/constructor/documentModel.ts
@@ -16,7 +16,6 @@ import {
 } from '..';
 import newPaginationStatus from './pagination';
 
-
 export function newExtent(obj: any): Extent {
     return {
         fst: (typeof obj.fst === 'number') ? parseFloat(obj.fst) : undefined,
@@ -47,7 +46,6 @@ export function newBoundingBox(obj: any): BoundingBox {
         y: newInterval(obj.y),
     };
 }
-
 
 export function newColumn(obj: any): Column {
     return {

--- a/src/services/dataModel.ts
+++ b/src/services/dataModel.ts
@@ -21,6 +21,11 @@ import { Pagination } from '../types/pagination';
 export class DataModelService implements Service {
     readonly subpath = '/datamodel';
 
+    readonly fieldKinds = [
+        DataModel.FieldKind.Element,
+        DataModel.FieldKind.Table,
+    ];
+
     /**
      * Remote service status
      * @return whether the service is alive or not
@@ -30,20 +35,6 @@ export class DataModelService implements Service {
         try {
             const resp = await reyahServiceRequest.get(subpath, false);
             return newServiceStatus(resp.data);
-        } catch (err) {
-            throw new ReyahError(err);
-        }
-    }
-
-    /**
-     * Available data model kinds
-     * @return Available kinds in data fields
-     */
-    public async availableKinds(): Promise<string[]> {
-        const subpath: string = `${this.subpath}/kinds`;
-        try {
-            const resp = await reyahServiceRequest.get(subpath, true);
-            return resp.data.kinds as string[];
         } catch (err) {
             throw new ReyahError(err);
         }

--- a/src/types/dataModel.ts
+++ b/src/types/dataModel.ts
@@ -4,17 +4,9 @@
 
 import { PaginationStatus } from './pagination';
 
-/**
- * Data model field property
- */
-export interface Property {
-    key: string;
-    value: string;
-}
-
-export interface PropertyRequest {
-    key: string;
-    value?: string;
+export enum FieldKind {
+    Element = 'ELEMENT',
+    Table = 'TABLE',
 }
 
 /**
@@ -23,13 +15,13 @@ export interface PropertyRequest {
 export interface Field {
     field_id: string;
     user_id: string;
-    kind: string;
+    kind: FieldKind;
     name: string;
     description: string;
-    properties: Property[];
     datatypes: string[];
     created_at: Date;
     updated_at: Date;
+    columns: string[],
 }
 
 export interface PaginatedFields {
@@ -38,20 +30,20 @@ export interface PaginatedFields {
 }
 
 export interface CreateFieldRequest {
-    kind: string;
+    kind: FieldKind;
     name: string;
     description?: string;
-    properties?: PropertyRequest[];
     datatypes: string[];
+    columns: string[],
 }
 
 export interface UpdateFieldRequest {
     field_id: string;
-    kind: string;
+    kind: FieldKind;
     name: string;
     description?: string;
-    properties?: PropertyRequest[];
     datatypes: string[];
+    columns: string[],
 }
 
 /**

--- a/src/types/documentModel.ts
+++ b/src/types/documentModel.ts
@@ -11,6 +11,18 @@ export enum PreviewStatus {
     ERRORED = 'ERRORED',
 }
 
+export enum AnchorOrientation {
+    Vertical = 'VERTICAL',
+    Horizontal = 'HORIZONTAL',
+}
+
+export enum GatherBoxDirection {
+    Up = 'UP',
+    Right = 'RIGHT',
+    Down = 'DOWN',
+    Left = 'LEFT',
+}
+
 /**
  * Represents a single field of a document model.
  */
@@ -19,22 +31,67 @@ export interface DocumentModelField {
     name: string;
     datamodel_field_id: string;
     description: string;
-    x: number;
-    y: number;
+    anchor: Anchor;
+    gatherBox: GatherBox;
+    element?: DocumentModelElementField;
+    table?: DocumentModelTableField;
+}
+
+export interface DocumentModelElementField {
+}
+
+export interface DocumentModelTableField {
+    columns: Column[];
+}
+
+export interface Column {
+    label?: string;
     width: number;
-    height: number;
-    created_at: Date;
-    updated_at: Date;
+}
+
+export interface Anchor {
+    box: BoundingBox;
+    orientation: AnchorOrientation;
+    label?: string;
+    padding?: Padding;
+}
+
+export interface GatherBox {
+    direction: GatherBoxDirection;
+    extent: Extent;
+}
+
+export interface Interval {
+    lo: number;
+    hi: number;
+}
+
+export interface BoundingBox {
+    x: Interval;
+    y: Interval;
+}
+
+export interface Padding {
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+}
+
+export interface Extent {
+    fst?: number;
+    snd?: number;
+    trd?: number;
 }
 
 export interface CreateDocumentModelFieldRequest {
     name: string;
     datamodel_field_id: string;
     description?: string;
-    x: number;
-    y: number;
-    width: number;
-    height: number;
+    anchor: Anchor;
+    gatherBox: GatherBox;
+    element?: DocumentModelElementField;
+    table?: DocumentModelTableField;
 }
 
 export interface UpdateDocumentModelFieldRequest {
@@ -42,10 +99,10 @@ export interface UpdateDocumentModelFieldRequest {
     name: string;
     datamodel_field_id: string;
     description?: string;
-    x: number;
-    y: number;
-    width: number;
-    height: number;
+    anchor: Anchor;
+    gatherBox: GatherBox;
+    element?: DocumentModelElementField;
+    table?: DocumentModelTableField;
 }
 
 /**
@@ -53,19 +110,21 @@ export interface UpdateDocumentModelFieldRequest {
  */
 export interface DocumentModel {
     id: string;
+    version: number,
     user_id: string;
     datamodel_id: string;
     name: string;
     description: string;
     fields: DocumentModelField[];
+    stoppers: Anchor[];
     preview_status: PreviewStatus;
     created_at: Date;
     updated_at: Date;
 }
 
 export interface PaginatedDocumentModels {
-    models: DocumentModel[],
-    pagination_status?: PaginationStatus,
+    models: DocumentModel[];
+    pagination_status?: PaginationStatus;
 }
 
 export interface CreateDocumentModelRequest {
@@ -73,6 +132,7 @@ export interface CreateDocumentModelRequest {
     name: string;
     description?: string;
     fields: DocumentModelField[];
+    stoppers: Anchor[];
 }
 
 export interface UpdateDocumentModelFieldWithModelRequest {
@@ -80,10 +140,10 @@ export interface UpdateDocumentModelFieldWithModelRequest {
     name: string;
     datamodel_field_id: string;
     description?: string;
-    x: number;
-    y: number;
-    width: number;
-    height: number;
+    anchor: Anchor;
+    gatherBox: GatherBox;
+    element?: DocumentModelElementField;
+    table?: DocumentModelTableField;
 }
 
 export interface UpdateDocumentModelRequest {
@@ -91,6 +151,7 @@ export interface UpdateDocumentModelRequest {
     name: string;
     description?: string;
     fields: UpdateDocumentModelFieldWithModelRequest[];
+    stoppers: Anchor[];
 }
 
 /**


### PR DESCRIPTION
This PR adds support to the SDK for the new generation of data and document models which includes (but is not limited to) support for tables and dynamically-sized capture regions.

Acropolis, Nyx and the SDK all have this branch called `feature/nextgen-models`.  
For the SDK, this branch includes the changes required to make it work with Acropolis and Nyx under their respective branch of the same name.  

Most notable changes in this PR:
- Changed type definitions to support the changes in Acropolis regarding the new data and document models.